### PR TITLE
Support legacy payload

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -253,7 +253,7 @@ class Resque_Job
 	public function recreate()
 	{
 		$monitor = false;
-		if (isset($this->payload['id'])) {
+		if (!empty($this->payload['id'])) {
 			$status = new Resque_Job_Status($this->payload['id'], $this->getPrefix());
 			if($status->isTracking()) {
 				$monitor = true;

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -175,9 +175,9 @@ class Resque_Job
 			return $this->instance;
 		}
 
-        $this->instance = $this->getJobFactory()->create($this->payload['class'], $this->getArguments(), $this->queue);
-        $this->instance->job = $this;
-        return $this->instance;
+		$this->instance = $this->getJobFactory()->create($this->payload['class'], $this->getArguments(), $this->queue);
+		$this->instance->job = $this;
+		return $this->instance;
 	}
 
 	/**
@@ -294,26 +294,26 @@ class Resque_Job
 		return $this;
 	}
 
-    /**
-     * @return Resque_Job_FactoryInterface
-     */
-    public function getJobFactory()
-    {
-        if ($this->jobFactory === null) {
-            $this->jobFactory = new Resque_Job_Factory();
-        }
-        return $this->jobFactory;
-    }
+	/**
+	 * @return Resque_Job_FactoryInterface
+	 */
+	public function getJobFactory()
+	{
+		if ($this->jobFactory === null) {
+			$this->jobFactory = new Resque_Job_Factory();
+		}
+		return $this->jobFactory;
+	}
 
-    /**
-     * @return string
-     */
-    private function getPrefix()
-    {
-    	if (isset($this->payload['prefix'])) {
-    		return $this->payload['prefix'];
-    	}
+	/**
+	 * @return string
+	 */
+	private function getPrefix()
+	{
+		if (isset($this->payload['prefix'])) {
+			return $this->payload['prefix'];
+		}
 
-    	return '';
-    }
+		return '';
+	}
 }

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -416,6 +416,30 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$instance = $job->getInstance();
 		$this->assertInstanceOf('Resque_JobInterface', $instance);
 	}
+
+	public function testJobStatusIsNullIfIdMissingFromPayload()
+	{
+		$payload = array(
+			'class' => 'Some_Job_Class',
+			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$this->assertEquals(null, $job->getStatus());
+	}
+
+	public function testJobCanBeRecreatedFromLegacyPayload()
+	{
+		$payload = array(
+			'class' => 'Some_Job_Class',
+			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$job->recreate();
+		$newJob = Resque_Job::reserve('jobs');
+		$this->assertEquals('jobs', $newJob->queue);
+		$this->assertEquals('Some_Job_Class', $newJob->payload['class']);
+		$this->assertNotNull($newJob->payload['id']);
+	}
 }
 
 class Some_Job_Class implements Resque_JobInterface


### PR DESCRIPTION
This fixes https://github.com/resque/php-resque/issues/31: `Undefined index id/prefix` e.g. when retrying via Resque Web.