### PR TITLE
fix trigger calls from scheduler

### DIFF
--- a/lib/ResqueScheduler.php
+++ b/lib/ResqueScheduler.php
@@ -10,7 +10,7 @@
 class ResqueScheduler
 {
 	const VERSION = "0.1";
-
+	
 	/**
 	 * Enqueue a job in a given number of seconds from now.
 	 *
@@ -45,7 +45,7 @@ class ResqueScheduler
 
 		$job = self::jobToHash($queue, $class, $args);
 		self::delayedPush($at, $job);
-
+		
 		Resque_Event::trigger('afterSchedule', array(
 			array(
 				'at'    => $at,
@@ -146,7 +146,7 @@ class ResqueScheduler
 
         return $count;
     }
-
+	
 	/**
 	 * Generate hash of all job properties to be saved in the scheduled queue.
 	 *
@@ -196,7 +196,7 @@ class ResqueScheduler
 		if ($timestamp instanceof DateTime) {
 			$timestamp = $timestamp->getTimestamp();
 		}
-
+		
 		if ((int)$timestamp != $timestamp) {
 			throw new ResqueScheduler_InvalidTimestampException(
 				'The supplied timestamp value could not be converted to an integer.'
@@ -226,15 +226,15 @@ class ResqueScheduler
 		else {
 			$at = self::getTimestamp($at);
 		}
-
+		
 		$items = Resque::redis()->zrangebyscore('delayed_queue_schedule', '-inf', $at, array('limit' => array(0, 1)));
 		if (!empty($items)) {
 			return $items[0];
 		}
-
+		
 		return false;
-	}
-
+	}	
+	
 	/**
 	 * Pop a job off the delayed queue for a given timestamp.
 	 *
@@ -245,9 +245,9 @@ class ResqueScheduler
 	{
 		$timestamp = self::getTimestamp($timestamp);
 		$key = 'delayed:' . $timestamp;
-
+		
 		$item = json_decode(Resque::redis()->lpop($key), true);
-
+		
 		self::cleanupTimestamp($key, $timestamp);
 		return $item;
 	}
@@ -267,7 +267,7 @@ class ResqueScheduler
 		else if (empty($queue)) {
 			throw new Resque_Exception('Jobs must be put in a queue.');
 		}
-
+		
 		return true;
 	}
 }

--- a/lib/ResqueScheduler.php
+++ b/lib/ResqueScheduler.php
@@ -226,7 +226,7 @@ class ResqueScheduler
 		else {
 			$at = self::getTimestamp($at);
 		}
-		
+	
 		$items = Resque::redis()->zrangebyscore('delayed_queue_schedule', '-inf', $at, array('limit' => array(0, 1)));
 		if (!empty($items)) {
 			return $items[0];

--- a/lib/ResqueScheduler.php
+++ b/lib/ResqueScheduler.php
@@ -10,7 +10,7 @@
 class ResqueScheduler
 {
 	const VERSION = "0.1";
-	
+
 	/**
 	 * Enqueue a job in a given number of seconds from now.
 	 *
@@ -45,13 +45,15 @@ class ResqueScheduler
 
 		$job = self::jobToHash($queue, $class, $args);
 		self::delayedPush($at, $job);
-		
+
 		Resque_Event::trigger('afterSchedule', array(
-			'at'    => $at,
-			'queue' => $queue,
-			'class' => $class,
-			'args'  => $args,
-		));
+            array(
+                'at'    => $at,
+                'queue' => $queue,
+                'class' => $class,
+                'args'  => $args,
+            )
+        ));
 	}
 
 	/**
@@ -144,7 +146,7 @@ class ResqueScheduler
 
         return $count;
     }
-	
+
 	/**
 	 * Generate hash of all job properties to be saved in the scheduled queue.
 	 *
@@ -194,7 +196,7 @@ class ResqueScheduler
 		if ($timestamp instanceof DateTime) {
 			$timestamp = $timestamp->getTimestamp();
 		}
-		
+
 		if ((int)$timestamp != $timestamp) {
 			throw new ResqueScheduler_InvalidTimestampException(
 				'The supplied timestamp value could not be converted to an integer.'
@@ -224,15 +226,15 @@ class ResqueScheduler
 		else {
 			$at = self::getTimestamp($at);
 		}
-	
+
 		$items = Resque::redis()->zrangebyscore('delayed_queue_schedule', '-inf', $at, array('limit' => array(0, 1)));
 		if (!empty($items)) {
 			return $items[0];
 		}
-		
+
 		return false;
-	}	
-	
+	}
+
 	/**
 	 * Pop a job off the delayed queue for a given timestamp.
 	 *
@@ -243,9 +245,9 @@ class ResqueScheduler
 	{
 		$timestamp = self::getTimestamp($timestamp);
 		$key = 'delayed:' . $timestamp;
-		
+
 		$item = json_decode(Resque::redis()->lpop($key), true);
-		
+
 		self::cleanupTimestamp($key, $timestamp);
 		return $item;
 	}
@@ -265,7 +267,7 @@ class ResqueScheduler
 		else if (empty($queue)) {
 			throw new Resque_Exception('Jobs must be put in a queue.');
 		}
-		
+
 		return true;
 	}
 }

--- a/lib/ResqueScheduler.php
+++ b/lib/ResqueScheduler.php
@@ -47,12 +47,12 @@ class ResqueScheduler
 		self::delayedPush($at, $job);
 
 		Resque_Event::trigger('afterSchedule', array(
-            array(
-                'at'    => $at,
-                'queue' => $queue,
-                'class' => $class,
-                'args'  => $args,
-            )
+			array(
+				'at'    => $at,
+				'queue' => $queue,
+				'class' => $class,
+				'args'  => $args,
+			)
         ));
 	}
 

--- a/lib/ResqueScheduler/Worker.php
+++ b/lib/ResqueScheduler/Worker.php
@@ -14,12 +14,12 @@ class ResqueScheduler_Worker
 	const LOG_NONE = 0;
 	const LOG_NORMAL = 1;
 	const LOG_VERBOSE = 2;
-
+	
 	/**
 	 * @var int Current log level of this worker.
 	 */
 	public $logLevel = 0;
-
+	
 	/**
 	 * @var int Interval to sleep for between checking schedules.
 	 */
@@ -62,7 +62,7 @@ class ResqueScheduler_Worker
 			$this->sleep();
 		}
 	}
-
+	
 	/**
 	 * Handle delayed items for the next scheduled timestamp.
 	 *
@@ -78,7 +78,7 @@ class ResqueScheduler_Worker
 			$this->enqueueDelayedItemsForTimestamp($oldestJobTimestamp);
 		}
 	}
-
+	
 	/**
 	 * Schedule all of the delayed jobs for a given timestamp.
 	 *
@@ -92,7 +92,7 @@ class ResqueScheduler_Worker
 		$item = null;
 		while ($item = ResqueScheduler::nextItemForTimestamp($timestamp)) {
 			$this->log('queueing ' . $item['class'] . ' in ' . $item['queue'] .' [delayed]');
-
+			
 			Resque_Event::trigger('beforeDelayedEnqueue', array(
 				array(
 					'queue' => $item['queue'],
@@ -105,7 +105,7 @@ class ResqueScheduler_Worker
 			call_user_func_array('Resque::enqueue', $payload);
 		}
 	}
-
+	
 	/**
 	 * Sleep for the defined interval.
 	 */
@@ -113,7 +113,7 @@ class ResqueScheduler_Worker
 	{
 		sleep($this->interval);
 	}
-
+	
 	/**
 	 * Update the status of the current worker process.
 	 *
@@ -129,7 +129,7 @@ class ResqueScheduler_Worker
 			setproctitle('resque-scheduler-' . ResqueScheduler::VERSION . ': ' . $status);
 		}
 	}
-
+	
 	/**
 	 * Output a given log message to STDOUT.
 	 *

--- a/lib/ResqueScheduler/Worker.php
+++ b/lib/ResqueScheduler/Worker.php
@@ -14,12 +14,12 @@ class ResqueScheduler_Worker
 	const LOG_NONE = 0;
 	const LOG_NORMAL = 1;
 	const LOG_VERBOSE = 2;
-	
+
 	/**
 	 * @var int Current log level of this worker.
 	 */
 	public $logLevel = 0;
-	
+
 	/**
 	 * @var int Interval to sleep for between checking schedules.
 	 */
@@ -62,7 +62,7 @@ class ResqueScheduler_Worker
 			$this->sleep();
 		}
 	}
-	
+
 	/**
 	 * Handle delayed items for the next scheduled timestamp.
 	 *
@@ -78,7 +78,7 @@ class ResqueScheduler_Worker
 			$this->enqueueDelayedItemsForTimestamp($oldestJobTimestamp);
 		}
 	}
-	
+
 	/**
 	 * Schedule all of the delayed jobs for a given timestamp.
 	 *
@@ -92,18 +92,20 @@ class ResqueScheduler_Worker
 		$item = null;
 		while ($item = ResqueScheduler::nextItemForTimestamp($timestamp)) {
 			$this->log('queueing ' . $item['class'] . ' in ' . $item['queue'] .' [delayed]');
-			
+
 			Resque_Event::trigger('beforeDelayedEnqueue', array(
-				'queue' => $item['queue'],
-				'class' => $item['class'],
-				'args'  => $item['args'],
-			));
+                array(
+                    'queue' => $item['queue'],
+                    'class' => $item['class'],
+                    'args'  => $item['args'],
+                )
+            ));
 
 			$payload = array_merge(array($item['queue'], $item['class']), $item['args']);
 			call_user_func_array('Resque::enqueue', $payload);
 		}
 	}
-	
+
 	/**
 	 * Sleep for the defined interval.
 	 */
@@ -111,7 +113,7 @@ class ResqueScheduler_Worker
 	{
 		sleep($this->interval);
 	}
-	
+
 	/**
 	 * Update the status of the current worker process.
 	 *
@@ -127,7 +129,7 @@ class ResqueScheduler_Worker
 			setproctitle('resque-scheduler-' . ResqueScheduler::VERSION . ': ' . $status);
 		}
 	}
-	
+
 	/**
 	 * Output a given log message to STDOUT.
 	 *

--- a/lib/ResqueScheduler/Worker.php
+++ b/lib/ResqueScheduler/Worker.php
@@ -94,11 +94,11 @@ class ResqueScheduler_Worker
 			$this->log('queueing ' . $item['class'] . ' in ' . $item['queue'] .' [delayed]');
 
 			Resque_Event::trigger('beforeDelayedEnqueue', array(
-                array(
-                    'queue' => $item['queue'],
-                    'class' => $item['class'],
-                    'args'  => $item['args'],
-                )
+				array(
+					'queue' => $item['queue'],
+					'class' => $item['class'],
+					'args'  => $item['args'],
+				)
             ));
 
 			$payload = array_merge(array($item['queue'], $item['class']), $item['args']);


### PR DESCRIPTION
It is called with `call_user_func_array()`, and that just does not work with arrays using key indexes. Adding another array around will make sure that the array is sent as first argument to event listener.

It actually crashes in php 8.