### PR TITLE
Only ping redis if Worker is unpaused

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -177,7 +177,7 @@ class Resque_Worker
 
 			// is redis still alive?
 			try {
-			    if (Resque::redis()->ping() === false) {
+			    if (!$this->paused && Resque::redis()->ping() === false) {
 			        throw new CredisException('redis ping() failed');
 			    }
 			} catch (CredisException $e) {


### PR DESCRIPTION
We pause the workers to be able to make updates to the redis. Unfortunately, this does not work, because the worker checks whether Reids can be reached and then crashes. I think that it is not necessary to check the connection when the worker is paused...