### PR TITLE
Clean up unit test output

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit
+          tools: phpunit:5
           extensions: redis
 
       - name: Setup problem matchers for PHP

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,17 +8,17 @@
 	convertWarningsToExceptions="true"
 	processIsolation="false"
 	stopOnFailure="false"
-	syntaxCheck="false"
 >
+
 	<testsuites>
 		<testsuite name="Resque Test Suite">
 			<directory>./test/Resque/</directory>
 		</testsuite>
 	</testsuites>
 
-	<filter>
-		<whitelist>
+	<coverage>
+		<include>
 			<directory suffix=".php">./lib/Resque/</directory>
-		</whitelist>
-	</filter>
+		</include>
+	</coverage>
 </phpunit>

--- a/test/Resque/Tests/JobPIDTest.php
+++ b/test/Resque/Tests/JobPIDTest.php
@@ -19,11 +19,14 @@ class Resque_Tests_JobPIDTest extends Resque_Tests_TestCase
 
 		// Register a worker to test with
 		$this->worker = new Resque_Worker('jobs');
-		$this->worker->setLogger(new Resque_Log());
+		$this->worker->setLogger($this->logger);
 	}
 
 	public function testQueuedJobDoesNotReturnPID()
 	{
+		$this->logger->expects($this->never())
+					 ->method('log');
+
 		$token = Resque::enqueue('jobs', 'Test_Job', null, true);
 		$this->assertEquals(0, Resque_Job_PID::get($token));
 	}

--- a/test/Resque/Tests/JobStatusTest.php
+++ b/test/Resque/Tests/JobStatusTest.php
@@ -19,7 +19,7 @@ class Resque_Tests_JobStatusTest extends Resque_Tests_TestCase
 
 		// Register a worker to test with
 		$this->worker = new Resque_Worker('jobs');
-		$this->worker->setLogger(new Resque_Log());
+		$this->worker->setLogger($this->logger);
 	}
 
 	public function testJobStatusCanBeTracked()

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -17,7 +17,7 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 
 		// Register a worker to test with
 		$this->worker = new Resque_Worker('jobs');
-		$this->worker->setLogger(new Resque_Log());
+		$this->worker->setLogger($this->logger);
 		$this->worker->registerWorker();
 	}
 
@@ -153,7 +153,7 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$job->worker = $this->worker;
 		$job->perform();
 	}
-	
+
 	public function testJobWithSetUpCallbackFiresSetUp()
 	{
 		$payload = array(
@@ -165,10 +165,10 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		);
 		$job = new Resque_Job('jobs', $payload);
 		$job->perform();
-		
+
 		$this->assertTrue(Test_Job_With_SetUp::$called);
 	}
-	
+
 	public function testJobWithTearDownCallbackFiresTearDown()
 	{
 		$payload = array(
@@ -180,7 +180,7 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		);
 		$job = new Resque_Job('jobs', $payload);
 		$job->perform();
-		
+
 		$this->assertTrue(Test_Job_With_TearDown::$called);
 	}
 
@@ -329,7 +329,7 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals(Resque::dequeue($queue, $test), 1);
 		#$this->assertEquals(Resque::size($queue), 1);
 	}
-	
+
 	public function testDequeueSeveralItemsWithArgs()
 	{
 		// GIVEN
@@ -340,11 +340,11 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		Resque::enqueue($queue, 'Test_Job_Dequeue9', $removeArgs);
 		Resque::enqueue($queue, 'Test_Job_Dequeue9', $removeArgs);
 		$this->assertEquals(Resque::size($queue), 3);
-		
+
 		// WHEN
 		$test = array('Test_Job_Dequeue9' => $removeArgs);
 		$removedItems = Resque::dequeue($queue, $test);
-		
+
 		// THEN
 		$this->assertEquals($removedItems, 2);
 		$this->assertEquals(Resque::size($queue), 1);
@@ -410,8 +410,10 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 			'args' => array(array())
 		);
 		$job = new Resque_Job('jobs', $payload);
-		$factory = $this->getMock('Resque_Job_FactoryInterface');
-		$testJob = $this->getMock('Resque_JobInterface');
+		$factory = $this->getMockBuilder('Resque_Job_FactoryInterface')
+			->getMock();
+		$testJob = $this->getMockBuilder('Resque_JobInterface')
+			->getMock();
 		$factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
 		$instance = $job->getInstance();
 		$this->assertInstanceOf('Resque_JobInterface', $instance);

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -10,6 +10,7 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 {
 	protected $resque;
 	protected $redis;
+	protected $logger;
 
 	public static function setUpBeforeClass()
 	{
@@ -21,6 +22,9 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 		$config = file_get_contents(REDIS_CONF);
 		preg_match('#^\s*port\s+([0-9]+)#m', $config, $matches);
 		$this->redis = new Credis_Client('localhost', $matches[1]);
+
+		$this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')
+							 ->getMock();
 
 		Resque::setBackend('redis://localhost:' . $matches[1]);
 

--- a/test/Resque/Tests/WorkerTest.php
+++ b/test/Resque/Tests/WorkerTest.php
@@ -11,7 +11,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testWorkerRegistersInList()
 	{
 		$worker = new Resque_Worker('*');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 
 		// Make sure the worker is in the list
@@ -24,7 +24,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 		// Register a few workers
 		for($i = 0; $i < $num; ++$i) {
 			$worker = new Resque_Worker('queue_' . $i);
-			$worker->setLogger(new Resque_Log());
+			$worker->setLogger($this->logger);
 			$worker->registerWorker();
 		}
 
@@ -35,7 +35,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testGetWorkerById()
 	{
 		$worker = new Resque_Worker('*');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 
 		$newWorker = Resque_Worker::find((string)$worker);
@@ -50,7 +50,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testWorkerCanUnregister()
 	{
 		$worker = new Resque_Worker('*');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 		$worker->unregisterWorker();
 
@@ -62,7 +62,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testPausedWorkerDoesNotPickUpJobs()
 	{
 		$worker = new Resque_Worker('*');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->pauseProcessing();
 		Resque::enqueue('jobs', 'Test_Job');
 		$worker->work(0);
@@ -73,7 +73,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testResumedWorkerPicksUpJobs()
 	{
 		$worker = new Resque_Worker('*');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->pauseProcessing();
 		Resque::enqueue('jobs', 'Test_Job');
 		$worker->work(0);
@@ -89,7 +89,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 			'queue1',
 			'queue2'
 		));
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 		Resque::enqueue('queue1', 'Test_Job_1');
 		Resque::enqueue('queue2', 'Test_Job_2');
@@ -108,7 +108,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 			'medium',
 			'low'
 		));
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 
 		// Queue the jobs in a different order
@@ -130,7 +130,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testWildcardQueueWorkerWorksAllQueues()
 	{
 		$worker = new Resque_Worker('*');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 
 		Resque::enqueue('queue1', 'Test_Job_1');
@@ -146,7 +146,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testWorkerDoesNotWorkOnUnknownQueues()
 	{
 		$worker = new Resque_Worker('queue1');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 		Resque::enqueue('queue2', 'Test_Job');
 
@@ -157,7 +157,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	{
 		Resque::enqueue('jobs', 'Test_Job');
 		$worker = new Resque_Worker('jobs');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$job = $worker->reserve();
 		$worker->workingOn($job);
 		$worker->doneWorking();
@@ -167,7 +167,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testWorkerRecordsWhatItIsWorkingOn()
 	{
 		$worker = new Resque_Worker('jobs');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 
 		$payload = array(
@@ -190,7 +190,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 		Resque::enqueue('jobs', 'Invalid_Job');
 
 		$worker = new Resque_Worker('jobs');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->work(0);
 		$worker->work(0);
 
@@ -202,18 +202,18 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	{
 		// Register a good worker
 		$goodWorker = new Resque_Worker('jobs');
-		$goodWorker->setLogger(new Resque_Log());
+		$goodWorker->setLogger($this->logger);
 		$goodWorker->registerWorker();
 		$workerId = explode(':', $goodWorker);
 
 		// Register some bad workers
 		$worker = new Resque_Worker('jobs');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->setId($workerId[0].':1:jobs');
 		$worker->registerWorker();
 
 		$worker = new Resque_Worker(array('high', 'low'));
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->setId($workerId[0].':2:high,low');
 		$worker->registerWorker();
 
@@ -229,14 +229,14 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	{
 		// Register a bad worker on this machine
 		$worker = new Resque_Worker('jobs');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$workerId = explode(':', $worker);
 		$worker->setId($workerId[0].':1:jobs');
 		$worker->registerWorker();
 
 		// Register some other false workers
 		$worker = new Resque_Worker('jobs');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->setId('my.other.host:1:jobs');
 		$worker->registerWorker();
 
@@ -253,7 +253,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
 	public function testWorkerFailsUncompletedJobsOnExit()
 	{
 		$worker = new Resque_Worker('jobs');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
 		$worker->registerWorker();
 
 		$payload = array(
@@ -270,7 +270,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
     public function testBlockingListPop()
     {
         $worker = new Resque_Worker('jobs');
-		$worker->setLogger(new Resque_Log());
+		$worker->setLogger($this->logger);
         $worker->registerWorker();
 
         Resque::enqueue('jobs', 'Test_Job_1');
@@ -296,7 +296,7 @@ class Resque_Tests_WorkerTest extends Resque_Tests_TestCase
         Resque::enqueue('jobs', 'Test_Infinite_Recursion_Job');
 
         $worker = new Resque_Worker('jobs');
-        $worker->setLogger(new Resque_Log());
+        $worker->setLogger($this->logger);
         $worker->work(0);
 
         $this->assertEquals(1, Resque_Stat::get('failed'));


### PR DESCRIPTION
- Use a mocked logger to remove output spam
- Fix phpunit deprecation warnings

This should fix all the issues scrutinizer has with the unit tests.