### PR TITLE
bin/resque: add support for connecting with a cluster client

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ Alternately, you can always `include('bin/resque')` from your application and
 skip setting `APP_INCLUDE` altogether.  Just be sure the various environment
 variables are set (`setenv`) before you do.
 
+### Clustering support
+
+Clustering support is automatically enabled when the `REDIS_BACKEND` environment
+variable contains a comma separated list of hostnames
+(`10.0.0.1:6379,10.0.0.2:6379`).
+
 ### Logging
 
 The port supports the same environment variables for logging to STDOUT. Setting

--- a/bin/resque
+++ b/bin/resque
@@ -40,11 +40,17 @@ $REDIS_BACKEND = getenv('REDIS_BACKEND');
 
 // A redis database number
 $REDIS_BACKEND_DB = getenv('REDIS_BACKEND_DB');
-if(!empty($REDIS_BACKEND)) {
-    if (empty($REDIS_BACKEND_DB))
-        Resque::setBackend($REDIS_BACKEND);
-    else
-        Resque::setBackend($REDIS_BACKEND, $REDIS_BACKEND_DB);
+
+if (!empty($REDIS_BACKEND)) {
+	if (empty($REDIS_BACKEND_DB)) {
+		if (stripos($REDIS_BACKEND, ',') !== false) {
+			Resque::setBackend(explode(",", $REDIS_BACKEND));
+		} else {
+			Resque::setBackend($REDIS_BACKEND);
+		}
+	} else {
+		Resque::setBackend($REDIS_BACKEND, $REDIS_BACKEND_DB);
+	}
 }
 
 $logLevel = false;


### PR DESCRIPTION
As `bin/resque` currently works, it pulls in the hostname to use from
the environment using `getenv`. The problem with this is that you cannot
pass in an array [which is what the underlying Redis library uses][1] to
determine whether it initialises a `Credis_Client` or a `Credit_Cluster`
for the connection.

This solves that issue by introducing support for passing a comma
separated list of hostnames to `REDIS_BACKEND` which will be expanded to
an array before passing to `Credis_Cluster`.

[1]: https://github.com/resque/php-resque/blob/master/lib/Resque/Redis.php#L128