### PR TITLE
feat: support for PHP 8.1

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -13,6 +13,8 @@ jobs:
         include:
           - php-versions: '8.0'
             experimental: true
+          - php-versions: '8.1'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit:5
+          tools: phpunit:8
           extensions: redis
 
       - name: Setup problem matchers for PHP

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"ext-redis": "Native PHP extension for Redis connectivity. Credis will automatically utilize when available."
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7"
+		"phpunit/phpunit": "^8.5"
 	},
 	"bin": [
 		"bin/resque",

--- a/lib/Resque/Log.php
+++ b/lib/Resque/Log.php
@@ -29,7 +29,7 @@ class Resque_Log extends Psr\Log\AbstractLogger
 		if ($this->verbose) {
 			fwrite(
 				STDOUT,
-				'[' . $level . '] [' . strftime('%T %Y-%m-%d') . '] ' . $this->interpolate($message, $context) . PHP_EOL
+				'[' . $level . '] [' . date('G:i:s Y-m-d', time()) . '] ' . $this->interpolate($message, $context) . PHP_EOL
 			);
 			return;
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -230,7 +230,7 @@ class Resque_Worker
 
 			// Forked and we're the child. Or PCNTL is not installed. Run the job.
 			if ($this->child === 0 || $this->child === false || $this->child === -1) {
-				$status = 'Processing ' . $job->queue . ' since ' . strftime('%F %T');
+				$status = 'Processing ' . $job->queue . ' since ' . date('Y-m-d H:i:s ', time());
 				$this->updateProcLine($status);
 				$this->logger->log(Psr\Log\LogLevel::INFO, $status);
 
@@ -251,7 +251,7 @@ class Resque_Worker
 
 			if ($this->child > 0) {
 				// Parent process, sit and wait
-				$status = 'Forked ' . $this->child . ' at ' . strftime('%F %T');
+				$status = 'Forked ' . $this->child . ' at ' . date('Y-m-d H:i:s ', time());
 				$this->updateProcLine($status);
 				$this->logger->log(Psr\Log\LogLevel::INFO, $status);
 

--- a/lib/ResqueScheduler/Worker.php
+++ b/lib/ResqueScheduler/Worker.php
@@ -139,7 +139,7 @@ class ResqueScheduler_Worker
 		if ($this->logLevel == self::LOG_NORMAL) {
 			fwrite(STDOUT, "*** " . $message . "\n");
 		} elseif ($this->logLevel == self::LOG_VERBOSE) {
-			fwrite(STDOUT, "** [" . strftime('%T %Y-%m-%d') . "] " . $message . "\n");
+			fwrite(STDOUT, "** [" . date('H:i:s Y-m-d', time()) . "] " . $message . "\n");
 		}
 	}
 

--- a/test/Resque/Tests/EventTest.php
+++ b/test/Resque/Tests/EventTest.php
@@ -10,7 +10,7 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 {
 	private $callbacksHit = array();
 
-	public function setUp()
+	public function setUp(): void
 	{
 		Test_Job::$called = false;
 
@@ -23,7 +23,7 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 		$this->worker->registerWorker();
 	}
 
-	public function tearDown()
+	public function tearDown(): void
 	{
 		Resque_Event::clearListeners();
 		$this->callbacksHit = array();
@@ -95,6 +95,7 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 		$callback = 'beforeEnqueueEventCallback';
 
 		Resque_Event::listen($event, array($this, $callback));
+		sleep(1);
 		Resque::enqueue('jobs', 'Test_Job', array(
 			'somevar'
 		));
@@ -160,7 +161,7 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 		throw new Resque_Job_DontPerform;
 	}
 
-	public function beforeEnqueueEventDontCreateCallback($queue, $class, $args, $track = false)
+	public function beforeEnqueueEventDontCreateCallback($queue, $class, $args, $id, $track = false)
 	{
 		$this->callbacksHit[] = __FUNCTION__;
 		throw new Resque_Job_DontCreate;
@@ -176,7 +177,7 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 		$this->assertEquals($args[0], 'somevar');
 	}
 
-	public function afterEnqueueEventCallback($class, $args)
+	public function afterEnqueueEventCallback($class, $args, $queue, $id)
 	{
 		$this->callbacksHit[] = __FUNCTION__;
 		$this->assertEquals('Test_Job', $class);
@@ -185,7 +186,7 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 		), $args);
 	}
 
-	public function beforeEnqueueEventCallback($job)
+	public function beforeEnqueueEventCallback($class, $args, $queue, $id)
 	{
 		$this->callbacksHit[] = __FUNCTION__;
 	}

--- a/test/Resque/Tests/EventTest.php
+++ b/test/Resque/Tests/EventTest.php
@@ -95,7 +95,6 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 		$callback = 'beforeEnqueueEventCallback';
 
 		Resque_Event::listen($event, array($this, $callback));
-		sleep(1);
 		Resque::enqueue('jobs', 'Test_Job', array(
 			'somevar'
 		));

--- a/test/Resque/Tests/JobPIDTest.php
+++ b/test/Resque/Tests/JobPIDTest.php
@@ -13,7 +13,7 @@ class Resque_Tests_JobPIDTest extends Resque_Tests_TestCase
 	 */
 	protected $worker;
 
-	public function setUp()
+	public function setUp(): void
 	{
 		parent::setUp();
 

--- a/test/Resque/Tests/JobStatusTest.php
+++ b/test/Resque/Tests/JobStatusTest.php
@@ -13,7 +13,7 @@ class Resque_Tests_JobStatusTest extends Resque_Tests_TestCase
 	 */
 	protected $worker;
 
-	public function setUp()
+	public function setUp(): void
 	{
 		parent::setUp();
 

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -11,7 +11,7 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 {
 	protected $worker;
 
-	public function setUp()
+	public function setUp(): void
 	{
 		parent::setUp();
 

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -26,11 +26,10 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertTrue((bool)Resque::enqueue('jobs', 'Test_Job'));
 	}
 
-	/**
-	 * @expectedException Resque_RedisException
-	 */
 	public function testRedisErrorThrowsExceptionOnJobCreation()
 	{
+		$this->expectException(Resque_RedisException::class);
+
 		$mockCredis = $this->getMockBuilder('Credis_Client')
 			->setMethods(['connect', '__call'])
 			->getMock();
@@ -55,11 +54,10 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals('Test_Job', $job->payload['class']);
 	}
 
-	/**
-	 * @expectedException InvalidArgumentException
-	 */
 	public function testObjectArgumentsCannotBePassedToJob()
 	{
+		$this->expectException(InvalidArgumentException::class);
+
 		$args = new stdClass;
 		$args->test = 'somevalue';
 		Resque::enqueue('jobs', 'Test_Job', $args);
@@ -132,22 +130,20 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals(1, Resque_Stat::get('failed:'.$this->worker));
 	}
 
-	/**
-	 * @expectedException Resque_Exception
-	 */
 	public function testJobWithoutPerformMethodThrowsException()
 	{
+		$this->expectException(Resque_Exception::class);
+
 		Resque::enqueue('jobs', 'Test_Job_Without_Perform_Method');
 		$job = $this->worker->reserve();
 		$job->worker = $this->worker;
 		$job->perform();
 	}
 
-	/**
-	 * @expectedException Resque_Exception
-	 */
 	public function testInvalidJobThrowsException()
 	{
+		$this->expectException(Resque_Exception::class);
+
 		Resque::enqueue('jobs', 'Invalid_Job');
 		$job = $this->worker->reserve();
 		$job->worker = $this->worker;
@@ -349,7 +345,7 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals($removedItems, 2);
 		$this->assertEquals(Resque::size($queue), 1);
 		$item = Resque::pop($queue);
-		$this->assertInternalType('array', $item['args']);
+		$this->assertIsArray($item['args']);
 		$this->assertEquals(10, $item['args'][0]['bar'], 'Wrong items were dequeued from queue!');
 	}
 

--- a/test/Resque/Tests/RedisTest.php
+++ b/test/Resque/Tests/RedisTest.php
@@ -8,11 +8,10 @@
  */
 class Resque_Tests_RedisTest extends Resque_Tests_TestCase
 {
-	/**
-	 * @expectedException Resque_RedisException
-	 */
 	public function testRedisExceptionsAreSurfaced()
 	{
+		$this->expectException(Resque_RedisException::class);
+
 		$mockCredis = $this->getMockBuilder('Credis_Client')
 			->setMethods(['connect', '__call'])
 			->getMock();
@@ -187,10 +186,11 @@ class Resque_Tests_RedisTest extends Resque_Tests_TestCase
 
 	/**
 	 * @dataProvider bogusDsnStringProvider
-	 * @expectedException InvalidArgumentException
 	 */
 	public function testParsingBogusDsnStringThrowsException($dsn)
 	{
+		$this->expectException(InvalidArgumentException::class);
+
 		// The next line should throw an InvalidArgumentException
 		$result = Resque_Redis::parseDsn($dsn);
 	}

--- a/test/Resque/Tests/RedisTest.php
+++ b/test/Resque/Tests/RedisTest.php
@@ -190,7 +190,6 @@ class Resque_Tests_RedisTest extends Resque_Tests_TestCase
 	public function testParsingBogusDsnStringThrowsException($dsn)
 	{
 		$this->expectException(InvalidArgumentException::class);
-
 		// The next line should throw an InvalidArgumentException
 		$result = Resque_Redis::parseDsn($dsn);
 	}

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -1,4 +1,7 @@
 <?php
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * Resque test case class. Contains setup and teardown methods.
  *
@@ -6,18 +9,18 @@
  * @author		Chris Boulton <chris@bigcommerce.com>
  * @license		http://www.opensource.org/licenses/mit-license.php
  */
-class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
+class Resque_Tests_TestCase extends TestCase
 {
 	protected $resque;
 	protected $redis;
 	protected $logger;
 
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 		date_default_timezone_set('UTC');
 	}
 
-	public function setUp()
+	public function setUp(): void
 	{
 		$config = file_get_contents(REDIS_CONF);
 		preg_match('#^\s*port\s+([0-9]+)#m', $config, $matches);


### PR DESCRIPTION
I used `main` as the base branch, since it appeared to be more up2date. If that was a mistake I'll gladly fix that and work from `develop`.

> Opened this PR as draft - since I wasn't able to test it completely on my machine and would like to rely on the CI at this stage. Especially since I cannot test multiple PHP versions that easily.

Depends on #56 

# Changes

- bumps `phpunit/phpunit` to `^8.5`
- replaces [deprecated](https://php.watch/versions/8.1/strftime-gmstrftime-deprecated) `strftime($format)` with `date($format, time())`
- adapts test classes that extend the PHPUnit Testcase to new version
  - using `PHPUnit\Framework\TestCase` over `PHPUnit_Framework_TestCase`
  - adds parameters to some test classes\*
  - replaces PHPDoc comments for expecting exceptions with `$this->expectException(Exception::class)`
  - replaces `$this->assertInternalType('array', $array)` with `$this->assertIsArray($array)`
---
\* According to [PHP 8.0 backward compatible changes](https://www.php.net/manual/en/migration80.incompatible.php) => [call_user_func_array()](https://www.php.net/manual/en/function.call-user-func-array.php) array keys will now be interpreted as parameter names, instead of being silently ignored.