### PR TITLE
fix: function strftime() is deprecated in PHP 8.1

### DIFF
--- a/lib/Logger.php
+++ b/lib/Logger.php
@@ -34,7 +34,7 @@ class Logger extends AbstractLogger
 		if ($this->verbose) {
 			fwrite(
 				STDOUT,
-				'[' . $level . '] [' . strftime('%T %Y-%m-%d') . '] ' . $this->interpolate($message, $context) . PHP_EOL
+				'[' . $level . '] [' . date('H:i:s Y-m-d') . '] ' . $this->interpolate($message, $context) . PHP_EOL
 			);
 			return;
 		}

--- a/lib/Worker/ResqueWorker.php
+++ b/lib/Worker/ResqueWorker.php
@@ -246,7 +246,7 @@ class ResqueWorker
 
 			// Forked and we're the child. Or PCNTL is not installed. Run the job.
 			if ($this->child === 0 || $this->child === false || $this->child === -1) {
-				$status = 'Processing ' . $job->queue . ' since ' . strftime('%F %T');
+				$status = 'Processing ' . $job->queue . ' since ' . date('Y-m-d H:i:s');
 				$this->updateProcLine($status);
 				$this->logger->log(LogLevel::INFO, $status);
 
@@ -267,7 +267,7 @@ class ResqueWorker
 
 			if ($this->child > 0) {
 				// Parent process, sit and wait
-				$status = 'Forked ' . $this->child . ' at ' . strftime('%F %T');
+				$status = 'Forked ' . $this->child . ' at ' . date('Y-m-d H:i:s');
 				$this->updateProcLine($status);
 				$this->logger->log(LogLevel::INFO, $status);
 

--- a/lib/Worker/SchedulerWorker.php
+++ b/lib/Worker/SchedulerWorker.php
@@ -144,7 +144,7 @@ class SchedulerWorker
 		if ($this->logLevel == self::LOG_NORMAL) {
 			fwrite(STDOUT, "*** " . $message . "\n");
 		} elseif ($this->logLevel == self::LOG_VERBOSE) {
-			fwrite(STDOUT, "** [" . strftime('%T %Y-%m-%d') . "] " . $message . "\n");
+			fwrite(STDOUT, "** [" . date('H:i:s Y-m-d') . "] " . $message . "\n");
 		}
 	}
 


### PR DESCRIPTION
Function `strftime` is deprecated in PHP 8.1. I have updated the code to use `date` instead.