### PR TITLE
Replace deprecated variable interpolation syntax in PHP 8.2

### DIFF
--- a/lib/Job/Status.php
+++ b/lib/Job/Status.php
@@ -50,7 +50,7 @@ class Status
 	public function __construct($id, $prefix = '')
 	{
 		$this->id = $id;
-		$this->prefix = empty($prefix) ? '' : "${prefix}_";
+		$this->prefix = empty($prefix) ? '' : "{$prefix}_";
 	}
 
 	/**


### PR DESCRIPTION
Using ${var} in strings is deprecated. This is the only instance where the deprecated syntax is used.