### PR TITLE
chore: add testing against modern PHP versions

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -15,6 +15,12 @@ jobs:
             experimental: true
           - php-versions: '8.1'
             experimental: true
+          - php-versions: '8.2'
+            experimental: true
+          - php-versions: '8.3'
+            experimental: true
+          - php-versions: '8.4'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This will allow CI to warn about problems in newer PHP versions. 