### PR TITLE
fix: use CI tooling as defined in Composer

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -21,7 +21,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          tools: phpunit:5
           extensions: redis
 
       - name: Setup problem matchers for PHP
@@ -37,7 +36,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Run PHPunit
-        run: phpunit --configuration phpunit.xml.dist
+        run: ./vendor/bin/phpunit --configuration phpunit.xml.dist
 
   phpcs:
     runs-on: ubuntu-latest
@@ -51,13 +50,13 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools: cs2pr, phpcs
+          tools: cs2pr
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
       - name: Run PHPCS
-        run: phpcs -q --report=checkstyle lib | cs2pr
+        run: ./vendor/bin/phpcs -q --report=checkstyle lib | cs2pr
 
   phpstan:
     runs-on: ubuntu-latest
@@ -71,7 +70,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          tools: phpstan
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
@@ -80,5 +78,5 @@ jobs:
         run: composer install
 
       - name: Run PHPStan
-        run: phpstan analyse lib -l1
+        run: ./vendor/bin/phpstan analyse lib -l1
 

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -46,11 +46,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup PHPCS
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           tools: cs2pr
+
+      - name: Install dependencies
+        run: composer install
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,9 @@
 		"ext-redis": "Native PHP extension for Redis connectivity. Credis will automatically utilize when available."
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7"
+		"phpunit/phpunit": "^5.7",
+		"squizlabs/php_codesniffer": "^3.10",
+		"phpstan/phpstan": "^1.12"
 	},
 	"bin": [
 		"bin/resque",


### PR DESCRIPTION
---
name: "Chore: use CI tooling as defined in Composer"
about: use CI tooling as defined in Composer!
labels: chore
---

## Description
Keeping the development and the CI versions separate is risky because they can get out of sync, this PR fixes that.

## Motivation and Context
Avoids running CI with tooling that developers won't

## How Has This Been Tested?
It will run in CI as a test

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
