### PR TITLE
Update to PHPUnit 9.5 and PHP 7.3

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -42,7 +42,7 @@ jobs:
 
   phpcs:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     name: "PHPCS"
     steps:
       - name: Checkout

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -13,6 +13,8 @@ jobs:
         include:
           - php-versions: '8.0'
             experimental: true
+          - php-versions: '8.1'
+            experimental: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6.0",
+		"php": ">=7.3.0",
 		"colinmollenhour/credis": "~1.7",
 		"psr/log": ">=1.1.0"
 	},
@@ -38,7 +38,7 @@
 		"ext-redis": "Native PHP extension for Redis connectivity. Credis will automatically utilize when available."
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^8.5",
+		"phpunit/phpunit": ">=9.0 <9.6",
 		"squizlabs/php_codesniffer": "^3.10",
 		"phpstan/phpstan": "^1.12"
 	},

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"ext-redis": "Native PHP extension for Redis connectivity. Credis will automatically utilize when available."
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7",
+		"phpunit/phpunit": "^8.5",
 		"squizlabs/php_codesniffer": "^3.10",
 		"phpstan/phpstan": "^1.12"
 	},

--- a/lib/Job/Status.php
+++ b/lib/Job/Status.php
@@ -13,10 +13,10 @@ use Resque\Resque;
  */
 class Status
 {
-	const STATUS_WAITING = 1;
-	const STATUS_RUNNING = 2;
-	const STATUS_FAILED = 3;
-	const STATUS_COMPLETE = 4;
+	public const STATUS_WAITING = 1;
+	public const STATUS_RUNNING = 2;
+	public const STATUS_FAILED = 3;
+	public const STATUS_COMPLETE = 4;
 
 	/**
 	 * @var string The prefix of the job status id.

--- a/lib/Redis.php
+++ b/lib/Redis.php
@@ -26,17 +26,17 @@ class Redis
 	/**
 	 * A default host to connect to
 	 */
-	const DEFAULT_HOST = 'localhost';
+	protected const DEFAULT_HOST = 'localhost';
 
 	/**
 	 * The default Redis port
 	 */
-	const DEFAULT_PORT = 6379;
+	protected const DEFAULT_PORT = 6379;
 
 	/**
 	 * The default Redis Database number
 	 */
-	const DEFAULT_DATABASE = 0;
+	protected const DEFAULT_DATABASE = 0;
 
 	/**
 	 * Connection driver

--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -14,9 +14,9 @@ use Resque\Exceptions\DoNotCreateException;
  */
 class Resque
 {
-	const VERSION = '1.2';
+	public const VERSION = '1.2';
 
-	const DEFAULT_INTERVAL = 5;
+	public const DEFAULT_INTERVAL = 5;
 
 	/**
 	 * @var Redis Instance of Resque\Redis that talks to redis.

--- a/lib/Scheduler.php
+++ b/lib/Scheduler.php
@@ -16,7 +16,7 @@ use DateTime;
 */
 class Scheduler
 {
-	const VERSION = "0.1";
+	public const VERSION = "0.1";
 
 	/**
 	 * Enqueue a job in a given number of seconds from now.

--- a/lib/Worker/SchedulerWorker.php
+++ b/lib/Worker/SchedulerWorker.php
@@ -17,9 +17,9 @@ use Resque\Event;
  */
 class SchedulerWorker
 {
-	const LOG_NONE = 0;
-	const LOG_NORMAL = 1;
-	const LOG_VERBOSE = 2;
+	public const LOG_NONE = 0;
+	public const LOG_NORMAL = 1;
+	public const LOG_VERBOSE = 2;
 
 	/**
 	 * @var int Current log level of this worker.

--- a/test/Resque/Tests/EventTest.php
+++ b/test/Resque/Tests/EventTest.php
@@ -21,6 +21,8 @@ class EventTest extends ResqueTestCase
 {
 	private $callbacksHit = array();
 
+	private $worker;
+
 	public function setUp(): void
 	{
 		Test_Job::$called = false;

--- a/test/Resque/Tests/EventTest.php
+++ b/test/Resque/Tests/EventTest.php
@@ -21,7 +21,7 @@ class EventTest extends ResqueTestCase
 {
 	private $callbacksHit = array();
 
-	public function setUp()
+	public function setUp(): void
 	{
 		Test_Job::$called = false;
 
@@ -34,7 +34,7 @@ class EventTest extends ResqueTestCase
 		$this->worker->registerWorker();
 	}
 
-	public function tearDown()
+	public function tearDown(): void
 	{
 		Event::clearListeners();
 		$this->callbacksHit = array();
@@ -171,7 +171,7 @@ class EventTest extends ResqueTestCase
 		throw new DoNotPerformException;
 	}
 
-	public function beforeEnqueueEventDontCreateCallback($queue, $class, $args, $track = false)
+	public function beforeEnqueueEventDontCreateCallback($queue, $class, $args, $id, $track = false)
 	{
 		$this->callbacksHit[] = __FUNCTION__;
 		throw new DoNotCreateException;
@@ -187,7 +187,7 @@ class EventTest extends ResqueTestCase
 		$this->assertEquals($args[0], 'somevar');
 	}
 
-	public function afterEnqueueEventCallback($class, $args)
+	public function afterEnqueueEventCallback($class, $args, $queue, $id)
 	{
 		$this->callbacksHit[] = __FUNCTION__;
 		$this->assertEquals('Test_Job', $class);
@@ -196,7 +196,7 @@ class EventTest extends ResqueTestCase
 		), $args);
 	}
 
-	public function beforeEnqueueEventCallback($job)
+	public function beforeEnqueueEventCallback($class, $args, $queue, $id)
 	{
 		$this->callbacksHit[] = __FUNCTION__;
 	}

--- a/test/Resque/Tests/JobHandlerTest.php
+++ b/test/Resque/Tests/JobHandlerTest.php
@@ -25,7 +25,7 @@ class JobHandlerTest extends ResqueTestCase
 {
 	protected $worker;
 
-	public function setUp()
+	public function setUp(): void
 	{
 		parent::setUp();
 

--- a/test/Resque/Tests/JobHandlerTest.php
+++ b/test/Resque/Tests/JobHandlerTest.php
@@ -40,11 +40,10 @@ class JobHandlerTest extends ResqueTestCase
 		$this->assertTrue((bool)Resque::enqueue('jobs', 'Test_Job'));
 	}
 
-	/**
-	 * @expectedException \Resque\Exceptions\RedisException
-	 */
 	public function testRedisErrorThrowsExceptionOnJobCreation()
 	{
+		$this->expectException('\Resque\Exceptions\RedisException');
+
 		$mockCredis = $this->getMockBuilder('Credis_Client')
 			->setMethods(['connect', '__call'])
 			->getMock();
@@ -69,11 +68,10 @@ class JobHandlerTest extends ResqueTestCase
 		$this->assertEquals('Test_Job', $job->payload['class']);
 	}
 
-	/**
-	 * @expectedException InvalidArgumentException
-	 */
 	public function testObjectArgumentsCannotBePassedToJob()
 	{
+		$this->expectException('InvalidArgumentException');
+
 		$args = new stdClass();
 		$args->test = 'somevalue';
 		Resque::enqueue('jobs', 'Test_Job', $args);
@@ -146,22 +144,20 @@ class JobHandlerTest extends ResqueTestCase
 		$this->assertEquals(1, Stat::get('failed:'.$this->worker));
 	}
 
-	/**
-	 * @expectedException \Resque\Exceptions\ResqueException
-	 */
 	public function testJobWithoutPerformMethodThrowsException()
 	{
+		$this->expectException('\Resque\Exceptions\ResqueException');
+
 		Resque::enqueue('jobs', 'Test_Job_Without_Perform_Method');
 		$job = $this->worker->reserve();
 		$job->worker = $this->worker;
 		$job->perform();
 	}
 
-	/**
-	 * @expectedException Resque\Exceptions\ResqueException
-	 */
 	public function testInvalidJobThrowsException()
 	{
+		$this->expectException('Resque\Exceptions\ResqueException');
+
 		Resque::enqueue('jobs', 'Invalid_Job');
 		$job = $this->worker->reserve();
 		$job->worker = $this->worker;
@@ -363,7 +359,7 @@ class JobHandlerTest extends ResqueTestCase
 		$this->assertEquals($removedItems, 2);
 		$this->assertEquals(Resque::size($queue), 1);
 		$item = Resque::pop($queue);
-		$this->assertInternalType('array', $item['args']);
+		$this->assertIsArray($item['args']);
 		$this->assertEquals(10, $item['args'][0]['bar'], 'Wrong items were dequeued from queue!');
 	}
 

--- a/test/Resque/Tests/JobPIDTest.php
+++ b/test/Resque/Tests/JobPIDTest.php
@@ -20,7 +20,7 @@ class JobPIDTest extends ResqueTestCase
 	 */
 	protected $worker;
 
-	public function setUp()
+	public function setUp(): void
 	{
 		parent::setUp();
 

--- a/test/Resque/Tests/JobStatusTest.php
+++ b/test/Resque/Tests/JobStatusTest.php
@@ -21,7 +21,7 @@ class JobStatusTest extends ResqueTestCase
 	 */
 	protected $worker;
 
-	public function setUp()
+	public function setUp(): void
 	{
 		parent::setUp();
 

--- a/test/Resque/Tests/RedisTest.php
+++ b/test/Resque/Tests/RedisTest.php
@@ -42,14 +42,14 @@ class RedisTest extends ResqueTestCase
 			// Input , Expected output
 			array('', array(
 				'localhost',
-				Redis::DEFAULT_PORT,
+				6379,
 				false,
 				false, false,
 				array(),
 			)),
 			array('localhost', array(
 				'localhost',
-				Redis::DEFAULT_PORT,
+				6379,
 				false,
 				false, false,
 				array(),
@@ -70,14 +70,14 @@ class RedisTest extends ResqueTestCase
 			)),
 			array('redis://foobar', array(
 				'foobar',
-				Redis::DEFAULT_PORT,
+				6379,
 				false,
 				false, false,
 				array(),
 			)),
 			array('redis://foobar/', array(
 				'foobar',
-				Redis::DEFAULT_PORT,
+				6379,
 				false,
 				false, false,
 				array(),

--- a/test/Resque/Tests/RedisTest.php
+++ b/test/Resque/Tests/RedisTest.php
@@ -15,11 +15,10 @@ use \Resque\Resque;
  */
 class RedisTest extends ResqueTestCase
 {
-	/**
-	 * @expectedException \Resque\Exceptions\RedisException
-	 */
 	public function testRedisExceptionsAreSurfaced()
 	{
+		$this->expectException('\Resque\Exceptions\RedisException');
+
 		$mockCredis = $this->getMockBuilder('Credis_Client')
 			->setMethods(['connect', '__call'])
 			->getMock();
@@ -194,10 +193,11 @@ class RedisTest extends ResqueTestCase
 
 	/**
 	 * @dataProvider bogusDsnStringProvider
-	 * @expectedException InvalidArgumentException
 	 */
 	public function testParsingBogusDsnStringThrowsException($dsn)
 	{
+		$this->expectException('InvalidArgumentException');
+
 		// The next line should throw an InvalidArgumentException
 		$result = Redis::parseDsn($dsn);
 	}

--- a/test/Resque/Tests/ResqueTestCase.php
+++ b/test/Resque/Tests/ResqueTestCase.php
@@ -3,7 +3,7 @@
 namespace Resque\Tests;
 
 use \Resque\Resque;
-use \PHPUnit_Framework_TestCase;
+use \PHPUnit\Framework\TestCase;
 use \Credis_Client;
 
 /**
@@ -13,18 +13,18 @@ use \Credis_Client;
  * @author		Chris Boulton <chris@bigcommerce.com>
  * @license		http://www.opensource.org/licenses/mit-license.php
  */
-class ResqueTestCase extends PHPUnit_Framework_TestCase
+class ResqueTestCase extends TestCase
 {
 	protected $resque;
 	protected $redis;
 	protected $logger;
 
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 		date_default_timezone_set('UTC');
 	}
 
-	public function setUp()
+	public function setUp(): void
 	{
 		$config = file_get_contents(REDIS_CONF);
 		preg_match('#^\s*port\s+([0-9]+)#m', $config, $matches);


### PR DESCRIPTION
This collects the rebased fixes from #62, as well as a couple more fixes on top for a newer version of phpunit and making the phpcs check pass.

phpunit 9.6 adds a whole bunch of deprecations that are subsequently removed in phpunit 10. I didn't actually test it, but that's probably a step left for later. For now this would get us reasonably forward in the stack.