### PR TITLE
Ignore phpunit security issue about PHPT test files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,13 @@
 			"Resque\\Tests\\": "test/Resque/Tests"
 		}
 	},
+	"config": {
+		"audit": {
+			"ignore": {
+				"PKSA-z3gr-8qht-p93v": "This project does not use PHPT tests, so CVE-2026-24765 is not applicable"
+			}
+		}
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "1.0-dev"


### PR DESCRIPTION
Doesn't affect php-resque